### PR TITLE
fixed Invalid argument Exception for adminhtml system.xml

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -125,6 +125,6 @@
                     </depends>
                 </field>                                                
             </group>
-        </section>		
+        </section>
     </system>
 </config>


### PR DESCRIPTION
fixed Exception #0 (Exception): Warning: Invalid argument supplied for foreach() in vendor/magento/module-config/Model/Config/Structure/Mapper/Sorting.php on line 34

little tab was at the end of the tag and destroyed the configuration handling after flushing the cache.