### PR TITLE
#16 Fix HTML Minify issue on view/frontend/templates/head.phtml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,11 +2,11 @@
     "name": "faonni/module-re-captcha",
     "description": "Extension is integrate Google Recaptcha with your Magento2 store.",
     "type": "magento2-module",
-	"version": "2.0.13",
+	"version": "2.0.14",
     "authors": [{
         "name" : "Karliuka Vitalii",
         "email": "karliuka.vitalii@gmail.com"
-    }],		
+    }],
 	"license": [
 		"OSL-3.0"
 	],
@@ -14,8 +14,8 @@
 		"magento/module-checkout": "100.0.*|100.1.*|100.2.*"
 	},
 	"autoload": {
-        "files": [ 
-            "registration.php" 
+        "files": [
+            "registration.php"
         ],
         "psr-4": {
             "Faonni\\ReCaptcha\\": ""

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -8,7 +8,7 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
 	xsi:noNamespaceSchemaLocation="../../../../../lib/internal/Magento/Framework/Module/etc/module.xsd">
-    <module name="Faonni_ReCaptcha" setup_version="2.0.13">
+    <module name="Faonni_ReCaptcha" setup_version="2.0.14">
         <sequence>
             <module name="Magento_Checkout"/>
         </sequence>

--- a/view/frontend/templates/head.phtml
+++ b/view/frontend/templates/head.phtml
@@ -6,5 +6,5 @@
  */
 ?>
 <?php if ($block->isEnabled()) : ?>
-	<script type="text/javascript" src='//www.google.com/recaptcha/api.js?render=explicit&hl=<?php echo $block->getLocale() ?>' defer></script>
+	<script type="text/javascript" src="https://www.google.com/recaptcha/api.js?render=explicit&hl=<?php echo $block->getLocale() ?>" defer></script>
 <?php endif ?>


### PR DESCRIPTION
Issue #16 is happening when the HTML Minify mode is activated.
It seems that everything after the // is removed on the rendering.

This fix is solving that.